### PR TITLE
Implement IDisposable

### DIFF
--- a/src/MinecraftClient/Client.cs
+++ b/src/MinecraftClient/Client.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Net.Sockets;
 using System.Threading;
 
 namespace MinecraftClient
 {
-	class MinecraftClient
+	class MinecraftClient : IDisposable
 	{
 		private const int MaxMessageSize = 4110; // 4096 + 14 bytes of header data.
 
@@ -16,6 +16,11 @@ namespace MinecraftClient
 		{
 			client = new TcpClient(host, port);
 			conn = client.GetStream();
+		}
+		
+		public void Dispose()
+		{
+		    this.Close();
 		}
 
 		public void Close()

--- a/src/MinecraftClient/Shell.cs
+++ b/src/MinecraftClient/Shell.cs
@@ -35,35 +35,35 @@ namespace MinecraftClient
 			}
 
 			// Connect and authenticate.
-			MinecraftClient client = new MinecraftClient(host, port);
-			if (!client.Authenticate(password))
+			using (MinecraftClient client = new MinecraftClient(host, port))
 			{
-				Console.WriteLine("authentication failure");
-				client.Close();
-				return;
-			}
-
-			// Start RCON shell.
-			List<String> quitCommands = new List<String> { "exit", "quit" };
-			Console.WriteLine("Starting RCON shell. Use 'exit', 'quit', or Ctrl-C to exit.");
-			while (true)
-			{
-				Console.Write("> ");
-				String command = Console.ReadLine();
-				if (quitCommands.Contains(command)) { break; }
-
-				Message resp;
-				if (client.SendCommand(command, out resp))
+				if (!client.Authenticate(password))
 				{
-					Console.WriteLine(resp.Body);
+					Console.WriteLine("authentication failure");
+					return;
 				}
-				else
+
+				// Start RCON shell.
+				List<String> quitCommands = new List<String> { "exit", "quit" };
+				Console.WriteLine("Starting RCON shell. Use 'exit', 'quit', or Ctrl-C to exit.");
+				while (true)
 				{
-					Console.WriteLine("Error sending command.");
-					break;
+					Console.Write("> ");
+					String command = Console.ReadLine();
+					if (quitCommands.Contains(command)) { break; }
+
+					Message resp;
+					if (client.SendCommand(command, out resp))
+					{
+						Console.WriteLine(resp.Body);
+					}
+					else
+					{
+						Console.WriteLine("Error sending command.");
+						break;
+					}
 				}
 			}
-			client.Close();
 		}
 	}
 }


### PR DESCRIPTION
This allows the use of `using` statements so that `Close()` doesn't have to be called explicitly.

https://ci.appveyor.com/project/ahwm/minecraft-client-csharp